### PR TITLE
Add ability to extend path links within your script.

### DIFF
--- a/com/dax/walker/DaxWalker.java
+++ b/com/dax/walker/DaxWalker.java
@@ -8,6 +8,7 @@ import com.dax.walker.models.*;
 import com.dax.walker.models.exceptions.AuthorizationException;
 import com.dax.walker.models.exceptions.RateLimitException;
 import com.dax.walker.models.exceptions.UnknownException;
+import com.dax.walker.store.DaxStore;
 import org.rspeer.runetek.adapter.Positionable;
 import org.rspeer.runetek.api.movement.position.Position;
 import org.rspeer.runetek.api.scene.Players;
@@ -21,12 +22,18 @@ public class DaxWalker {
 
     private Server server;
     private WalkerEngine walkerEngine;
+    private DaxStore store;
     private boolean useTeleports;
 
     public DaxWalker(Server server) {
         this.server = server;
-        this.walkerEngine = new WalkerEngine();
+        this.store = new DaxStore();
+        this.walkerEngine = new WalkerEngine(null, this);
         this.useTeleports = true;
+    }
+
+    public DaxStore getStore() {
+        return store;
     }
 
     /**

--- a/com/dax/walker/engine/BrokenPathHandler.java
+++ b/com/dax/walker/engine/BrokenPathHandler.java
@@ -20,6 +20,7 @@ import org.rspeer.ui.Log;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.logging.Level;
@@ -107,8 +108,8 @@ public class BrokenPathHandler {
         return PathHandleState.FAILED;
     }
 
-    public static PathHandleState handlePathLink(Position start, Position end, WalkCondition walkCondition) {
-        PathLink pathLink = Arrays.stream(PathLink.values())
+    public static PathHandleState handlePathLink(Position start, Position end, WalkCondition walkCondition, List<PathLink> pathLinks) {
+        PathLink pathLink = pathLinks.stream()
                 .filter(link -> link.getStart().equals(start) && link.getEnd().equals(end))
                 .findAny()
                 .orElse(null);

--- a/com/dax/walker/engine/PathHandler.java
+++ b/com/dax/walker/engine/PathHandler.java
@@ -2,6 +2,7 @@ package com.dax.walker.engine;
 
 import com.allatori.annotations.DoNotRename;
 import com.dax.walker.engine.definitions.PathHandleState;
+import com.dax.walker.engine.definitions.PathLink;
 import com.dax.walker.engine.definitions.Teleport;
 import com.dax.walker.engine.definitions.WalkCondition;
 import com.dax.walker.engine.pathfinding.BFSMapCache;
@@ -29,7 +30,7 @@ public class PathHandler {
      * @param maxRetries       max retries on fail
      * @return true if path completed successfully.
      */
-    public static boolean walk(List<Position> path, WalkCondition walkCondition, int maxRetries) {
+    public static boolean walk(List<Position> path, WalkCondition walkCondition, int maxRetries, List<PathLink> pathLinks) {
         assert Thread.currentThread() instanceof Script;
         Script script = (Script) Thread.currentThread();
 
@@ -50,7 +51,7 @@ public class PathHandler {
             Time.sleep(50);
             if (fail >= maxRetries) return false;
             Position next = furthestTileInPath(path, randomDestinationDistance());
-            PathHandleState state = handleNextAction(previous, next, path, walkCondition);
+            PathHandleState state = handleNextAction(previous, next, path, walkCondition, pathLinks);
 
 
             switch (state) {
@@ -73,7 +74,7 @@ public class PathHandler {
         return true;
     }
 
-    private static PathHandleState handleNextAction(Position previous, Position now, List<Position> path, WalkCondition walkCondition) {
+    private static PathHandleState handleNextAction(Position previous, Position now, List<Position> path, WalkCondition walkCondition, List<PathLink> pathLinks) {
         if (ShipHandler.isOnShip()) return ShipHandler.getOffBoat() ? PathHandleState.SUCCESS : PathHandleState.FAILED;
         if (now == null) return PathHandleState.FAILED;
 
@@ -85,7 +86,7 @@ public class PathHandler {
                         now.getX(), now.getY(), now.getFloorLevel(),
                         next.getX(), next.getY(), next.getFloorLevel()
                 ));
-                PathHandleState pathHandleState = BrokenPathHandler.handlePathLink(now, next, walkCondition);
+                PathHandleState pathHandleState = BrokenPathHandler.handlePathLink(now, next, walkCondition, pathLinks);
                 if (pathHandleState != null) return pathHandleState;
                 return BrokenPathHandler.handle(now, next, walkCondition);
             }

--- a/com/dax/walker/engine/WalkerEngine.java
+++ b/com/dax/walker/engine/WalkerEngine.java
@@ -2,6 +2,7 @@ package com.dax.walker.engine;
 
 import com.allatori.annotations.DoNotRename;
 import com.dax.api.paint.debug.PositionalDebug;
+import com.dax.walker.DaxWalker;
 import com.dax.walker.engine.definitions.Teleport;
 import com.dax.walker.engine.definitions.WalkCondition;
 import com.dax.walker.engine.pathfinding.BFSMapCache;
@@ -33,17 +34,15 @@ public class WalkerEngine implements RenderListener {
     private Map<Position, Teleport> map;
     private WalkCondition walkCondition;
     private RunEnergyManager runEnergyManager;
+    private DaxWalker instance;
 
     // DEBUG PAINT
     private PathResult lastPath;
     private BFSMapCache bfsMapCache;
     private Position playerPosition;
 
-    public WalkerEngine() {
-        this(null);
-    }
-
-    public WalkerEngine(WalkCondition walkCondition) {
+    public WalkerEngine(WalkCondition walkCondition, DaxWalker instance) {
+        this.instance = instance;
         map = new ConcurrentHashMap<>();
         for (Teleport teleport : Teleport.values()) {
             map.put(teleport.getLocation(), teleport);
@@ -75,7 +74,7 @@ public class WalkerEngine implements RenderListener {
             }
             lastPath = pathResult;
             Log.log(Level.FINE, "DaxWalker", String.format("Chose path of cost: %d out of %d options.", pathResult.getCost(), validPaths.size()));
-            return PathHandler.walk(convert(pathResult.getPath()), walkCondition, 3);
+            return PathHandler.walk(convert(pathResult.getPath()), walkCondition, 3, instance.getStore().getPathLinks());
         } finally {
             Game.getEventDispatcher().deregister(this);
         }

--- a/com/dax/walker/engine/definitions/PathLink.java
+++ b/com/dax/walker/engine/definitions/PathLink.java
@@ -7,193 +7,230 @@ import org.rspeer.runetek.api.movement.position.Position;
 import org.rspeer.runetek.api.movement.transportation.CharterShip;
 import org.rspeer.ui.Log;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 
-public enum PathLink {
-    
-    KARAMJA_PORT_SARIM(
-            new Position(2953, 3146, 0), new Position(3029, 3217, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)pay.fare"), start, end, walkCondition)
-    ),
-    
-    KARAMJA_PORT_PHASMATYS(
-            new Position(2953, 3146, 0),  new Position(3702, 3503, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_PHASMATYS, walkCondition)
-    ),
-    PORT_PHASMATYS_KARAMJA(
-            new Position(3702, 3503, 0), new Position(2953, 3146, 0),
+public class PathLink {
+
+    private static List<PathLink> values;
+
+    public static final PathLink KARAMJA_PORT_SARIM =
+            new PathLink(new Position(2953, 3146, 0), new Position(3029, 3217, 0),
+                    (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)pay.fare"), start, end, walkCondition));
+
+    public static final PathLink KARAMJA_PORT_PHASMATYS = new PathLink(new Position(2953, 3146, 0), new Position(3702, 3503, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_PHASMATYS, walkCondition));
+
+    public static final PathLink PORT_PHASMATYS_KARAMJA = new PathLink(new Position(3702, 3503, 0), new Position(2953, 3146, 0),
             (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.MUSA_POINT, walkCondition)
-    ),
-    
-    PORT_PHASMATYS_PORTSARIM(
-            new Position(3702, 3503, 0), new Position(2796, 3414, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_PHASMATYS, walkCondition)
-    ),
-    
-    PORT_SARIM_PORT_PHASMATYS(
-            new Position(2796, 3414, 0), new Position(3702, 3503, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_PHASMATYS, walkCondition)
-    ),
-    
-    PORT_SARIM_CATHERBY(
-            new Position(3041, 3193, 0), new Position(2796, 3414, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.CATHERBY, walkCondition)
-    ),
-    
-    PORT_SARIM_BRIMHAVEN(
-            new Position(3041, 3193, 0), new Position(2760, 3237, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.BRIMHAVEN, walkCondition)
-    ),
-    
-    PORT_SARIM_KARAMJA(
-            new Position(3029, 3217, 0), new Position(2953, 3146, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)pay.fare"), start, end, walkCondition)
-    ),
-    
-    CATHERBY_PORT_SARIM(
-            new Position(2796, 3414, 0), new Position(3041, 3193, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_SARIM, walkCondition)
-    ),
-    
-    CATHERBY_PORT_BRIMHAVEN(
-            new Position(2796, 3414, 0), new Position(2760, 3237, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.BRIMHAVEN, walkCondition)
-    ),
-    
-    CATHERBY_MUSA_POINT(
-            new Position(2796, 3414, 0), new Position(2953, 3146, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.MUSA_POINT, walkCondition)
-    ),
-    
-    CATHERBY_PORT_KHAZARD(
-            new Position(2796, 3414, 0), new Position(2673, 3148, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_KHAZARD, walkCondition)
-    ),
-    
-    BRIMHAVEN_ARDOUGHNE(
-            new Position(2772, 3225, 0), new Position(2681, 3275, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)pay.fare"), start, end, walkCondition)
-    ),
-    
-    ARDOUGHNE_BRIMHAVEN(
-            new Position(2681, 3275, 0), new Position(2772, 3225, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)pay.fare"), start, end, walkCondition)
-    ),
-    
-    BRIMHAVEN_PORT_SARIM (
-            new Position(2760, 3237, 0), new Position(2953, 3146, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_SARIM, walkCondition)
-    ),
-    
-    KHAZARD_CATHERBY(
-            new Position(2673, 3148, 0), new Position(2796, 3414, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.CATHERBY, walkCondition)
-    ),
-    
-    KHAZARD_PORT_SARIM(
-            new Position(2673, 3148, 0), new Position(3041, 3193, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_SARIM, walkCondition)
-    ),
-    
-    PORT_SARIM_KHAZARD(
-            new Position(3041, 3193, 0), new Position(2673, 3148, 0),
-            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_KHAZARD, walkCondition)
-    ),
-    
-    PORT_SARIM_PEST_CONTROL(
-            new Position(3041, 3202, 0), new Position(2659, 2676, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)travel"), start, end, walkCondition)
-    ),
-    
-    PEST_CONTROL_PORT_SARIM(
-            new Position(2659, 2676, 0), new Position(3041, 3202, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)travel"), start, end, walkCondition)
-    ),
-    
-    PORT_SARIM_PISCARILIUS(
-            new Position(3054, 3245, 0), new Position(1824, 3691, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)port pis.+"), start, end, walkCondition)
-    ),
-    
-    PORT_SARIM_LANDS_END(
-            new Position(3054, 3245, 0), new Position(1504, 3399, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)land.s end"), start, end, walkCondition)
-    ),
-    
-    LANDS_END_PISCARILIUS(
-            new Position(1504, 3399, 0), new Position(1824, 3691, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)port pis.+"), start, end, walkCondition)
-    ),
-    
-    LANDS_END_PORT_SARIM(
-            new Position(1504, 3399, 0), new Position(3054, 3245, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)port sarim"), start, end, walkCondition)
-    ),
-    
-    PISCARILIUS_LANDS_END(
-            new Position(1824, 3691, 0), new Position(1504, 3399, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)land.s end"), start, end, walkCondition)
-    ),
-    
-    PISCARILIUS_PORT_SARIM(
-            new Position(1824, 3691, 0), new Position(3054, 3245, 0),
-            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)port sarim"), start, end, walkCondition)
-    ),
-    
-    LUMBRIDGE_HAM_HIDEOUT(
-            new Position(3166, 3251, 0), new Position(3149, 9652, 0),
-            LockPickHandler::handle
-    ),
-    
-    HAM_JAIL(
-            new Position(3183, 9611, 0), new Position(3182, 9611, 0),
-            LockPickHandler::handle
-    ),
-    
-    BURTHORP_DOWNSTAIRS (
-            new Position(2899, 3565, 0), new Position(2205, 4934, 1),
-            (start, end, walkCondition) -> BrokenPathHandler.NextMove.FLOOR_UNDER.handle() ? PathHandleState.SUCCESS : PathHandleState.FAILED
-    ),
-    
-    BURTHORP_UPSTAIRS (
-            new Position(2205, 4934, 1), new Position(2899, 3565, 0),
-            (start, end, walkCondition) -> BrokenPathHandler.NextMove.FLOOR_ABOVE.handle() ? PathHandleState.SUCCESS : PathHandleState.FAILED
-    ),
-    
-    PORT_PHASMATYS_SOUTH (
-            new Position(3659, 3507 ,0), new Position(3659, 3509, 0),
-            (start, end, walkCondition) -> BrokenPathHandler.NextMove.SAME_FLOOR.handle() ? PathHandleState.SUCCESS : PathHandleState.FAILED
-    ),
-    
-    
-    DEATH_PLATEAU_DUNGEON (
-            new Position(2858, 3577, 0), new Position(2269,4752,0),
-            (start, end, walkCondition) -> BrokenPathHandler.NextMove.SAME_FLOOR.handle() ? PathHandleState.SUCCESS : PathHandleState.FAILED
     );
-    
+
+    public static final PathLink PORT_PHASMATYS_PORTSARIM = new PathLink(new Position(3702, 3503, 0), new
+            Position(2796, 3414, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_PHASMATYS, walkCondition)
+    );
+
+    public static final PathLink PORT_SARIM_PORT_PHASMATYS = new PathLink(new Position(2796, 3414, 0), new
+            Position(3702, 3503, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_PHASMATYS, walkCondition)
+    );
+
+    public static final PathLink PORT_SARIM_CATHERBY = new PathLink(new Position(3041, 3193, 0), new
+            Position(2796, 3414, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.CATHERBY, walkCondition)
+    );
+
+    public static final PathLink PORT_SARIM_BRIMHAVEN = new PathLink(new Position(3041, 3193, 0), new
+            Position(2760, 3237, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.BRIMHAVEN, walkCondition)
+    );
+
+    public static final PathLink PORT_SARIM_KARAMJA = new PathLink(new Position(3029, 3217, 0), new
+            Position(2953, 3146, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)pay.fare"), start, end, walkCondition)
+    );
+
+    public static final PathLink CATHERBY_PORT_SARIM = new PathLink(new Position(2796, 3414, 0), new
+            Position(3041, 3193, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_SARIM, walkCondition)
+    );
+
+    public static final PathLink CATHERBY_PORT_BRIMHAVEN = new PathLink(new Position(2796, 3414, 0), new
+            Position(2760, 3237, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.BRIMHAVEN, walkCondition)
+    );
+
+    public static final PathLink CATHERBY_MUSA_POINT = new PathLink(new Position(2796, 3414, 0), new
+            Position(2953, 3146, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.MUSA_POINT, walkCondition)
+    );
+
+    public static final PathLink CATHERBY_PORT_KHAZARD = new PathLink(new Position(2796, 3414, 0), new
+            Position(2673, 3148, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_KHAZARD, walkCondition)
+    );
+
+    public static PathLink BRIMHAVEN_ARDOUGHNE = new PathLink(new Position(2772, 3225, 0), new
+            Position(2681, 3275, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)pay.fare"), start, end, walkCondition)
+    );
+
+    public static final PathLink ARDOUGHNE_BRIMHAVEN = new PathLink(new Position(2681, 3275, 0), new
+            Position(2772, 3225, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)pay.fare"), start, end, walkCondition)
+    );
+
+    public static final PathLink BRIMHAVEN_PORT_SARIM = new PathLink(new Position(2760, 3237, 0), new
+            Position(2953, 3146, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_SARIM, walkCondition)
+    );
+
+    public static final PathLink KHAZARD_CATHERBY = new PathLink(new Position(2673, 3148, 0), new
+            Position(2796, 3414, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.CATHERBY, walkCondition)
+    );
+
+    public static final PathLink KHAZARD_PORT_SARIM = new PathLink(
+            new Position(2673, 3148, 0), new
+            Position(3041, 3193, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_SARIM, walkCondition)
+    );
+
+    public static final PathLink PORT_SARIM_KHAZARD = new PathLink(new Position(3041, 3193, 0), new
+            Position(2673, 3148, 0),
+            (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_KHAZARD, walkCondition)
+    );
+
+    public static final PathLink PORT_SARIM_PEST_CONTROL = new PathLink(new Position(3041, 3202, 0), new
+            Position(2659, 2676, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)travel"), start, end, walkCondition)
+    );
+
+    public static final PathLink PEST_CONTROL_PORT_SARIM = new PathLink(new Position(2659, 2676, 0), new
+
+            Position(3041, 3202, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)travel"), start, end, walkCondition)
+    );
+
+    public static final PathLink PORT_SARIM_PISCARILIUS = new PathLink(new Position(3054, 3245, 0), new Position(1824, 3691, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)port pis.+"), start, end, walkCondition));
+
+    public static final PathLink PORT_SARIM_LANDS_END = new PathLink(new Position(3054, 3245, 0), new
+            Position(1504, 3399, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)land.s end"), start, end, walkCondition)
+    );
+
+    public static final PathLink LANDS_END_PISCARILIUS = new PathLink(new Position(1504, 3399, 0), new
+            Position(1824, 3691, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)port pis.+"), start, end, walkCondition)
+    );
+
+    public static final PathLink LANDS_END_PORT_SARIM = new PathLink(new Position(1504, 3399, 0), new
+            Position(3054, 3245, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)port sarim"), start, end, walkCondition)
+    );
+
+    public static final PathLink PISCARILIUS_LANDS_END = new PathLink(new Position(1824, 3691, 0), new
+            Position(1504, 3399, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)land.s end"), start, end, walkCondition)
+    );
+
+    public static final PathLink PISCARILIUS_PORT_SARIM = new PathLink(
+            new Position(1824, 3691, 0), new
+            Position(3054, 3245, 0),
+            (start, end, walkCondition) -> EntityHandler.handleWithAction(Pattern.compile("(?i)port sarim"), start, end, walkCondition)
+    );
+
+    public static final PathLink LUMBRIDGE_HAM_HIDEOUT = new PathLink(new Position(3166, 3251, 0), new
+            Position(3149, 9652, 0),
+            LockPickHandler::handle);
+
+    public static final PathLink HAM_JAIL = new PathLink(new Position(3183, 9611, 0), new
+            Position(3182, 9611, 0),
+            LockPickHandler::handle);
+
+    public static final PathLink BURTHORP_DOWNSTAIRS = new PathLink(new Position(2899, 3565, 0), new
+            Position(2205, 4934, 1),
+            (start, end, walkCondition) -> BrokenPathHandler.NextMove.FLOOR_UNDER.handle() ? PathHandleState.SUCCESS : PathHandleState.FAILED);
+
+    public static final PathLink BURTHORP_UPSTAIRS = new PathLink(new Position(2205, 4934, 1), new
+            Position(2899, 3565, 0),
+            (start, end, walkCondition) -> BrokenPathHandler.NextMove.FLOOR_ABOVE.handle() ? PathHandleState.SUCCESS : PathHandleState.FAILED);
+
+    public static final PathLink PORT_PHASMATYS_SOUTH = new PathLink(new Position(3659, 3507, 0), new
+            Position(3659, 3509, 0),
+            (start, end, walkCondition) -> BrokenPathHandler.NextMove.SAME_FLOOR.handle() ? PathHandleState.SUCCESS : PathHandleState.FAILED);
+
+
+    public static final PathLink DEATH_PLATEAU_DUNGEON = new PathLink(new Position(2858, 3577, 0), new
+            Position(2269, 4752, 0),
+            (start, end, walkCondition) -> BrokenPathHandler.NextMove.SAME_FLOOR.handle() ? PathHandleState.SUCCESS : PathHandleState.FAILED);
+
+
+    static {
+        values = new ArrayList<>();
+        values.add(KARAMJA_PORT_SARIM);
+        values.add(KARAMJA_PORT_PHASMATYS);
+        values.add(PORT_PHASMATYS_KARAMJA);
+        values.add(PORT_PHASMATYS_PORTSARIM);
+        values.add(PORT_SARIM_PORT_PHASMATYS);
+        values.add(PORT_SARIM_CATHERBY);
+        values.add(PORT_SARIM_BRIMHAVEN);
+        values.add(PORT_SARIM_KARAMJA);
+        values.add(CATHERBY_PORT_SARIM);
+        values.add(CATHERBY_PORT_BRIMHAVEN);
+        values.add(CATHERBY_MUSA_POINT);
+        values.add(CATHERBY_PORT_KHAZARD);
+        values.add(BRIMHAVEN_ARDOUGHNE);
+        values.add(ARDOUGHNE_BRIMHAVEN);
+        values.add(BRIMHAVEN_PORT_SARIM);
+        values.add(KHAZARD_CATHERBY);
+        values.add(KHAZARD_PORT_SARIM);
+        values.add(PORT_SARIM_KHAZARD);
+        values.add(PORT_SARIM_PEST_CONTROL);
+        values.add(PEST_CONTROL_PORT_SARIM);
+        values.add(PORT_SARIM_PISCARILIUS);
+        values.add(PORT_SARIM_LANDS_END);
+        values.add(LANDS_END_PISCARILIUS);
+        values.add(LANDS_END_PORT_SARIM);
+        values.add(PISCARILIUS_LANDS_END);
+        values.add(PISCARILIUS_PORT_SARIM);
+        values.add(LUMBRIDGE_HAM_HIDEOUT);
+        values.add(HAM_JAIL);
+        values.add(BURTHORP_DOWNSTAIRS);
+        values.add(BURTHORP_UPSTAIRS);
+        values.add(PORT_PHASMATYS_SOUTH);
+        values.add(DEATH_PLATEAU_DUNGEON);
+    }
+
+    public static List<PathLink> getValues() {
+        return values;
+    }
+
     private Position a;
     private Position b;
     private PathLinkHandler pathLinkHandler;
-    
-    PathLink(Position start, Position end, PathLinkHandler pathLinkHandler) {
+
+    public PathLink(Position start, Position end, PathLinkHandler pathLinkHandler) {
         this.a = start;
         this.b = end;
         this.pathLinkHandler = pathLinkHandler;
     }
-    
+
     public Position getStart() {
         return a;
     }
-    
+
     public Position getEnd() {
         return b;
     }
-    
+
     public PathHandleState handle(WalkCondition walkCondition) {
         Log.log(Level.FINE, "DaxWalker", "Triggering " + this);
         return this.pathLinkHandler.handle(a, b, walkCondition);
     }
-    
+
 }
     

--- a/com/dax/walker/models/PlayerDetails.java
+++ b/com/dax/walker/models/PlayerDetails.java
@@ -20,8 +20,10 @@ public class PlayerDetails {
 
     public static PlayerDetails generate() {
         List<IntPair> inventory = Arrays.stream(Inventory.getItems())
+                .filter(s -> !s.getName().equals("Members object"))
                 .map(rsItem -> new IntPair(rsItem.getId(), rsItem.getStackSize())).collect(Collectors.toList());
         List<IntPair> equipment = Arrays.stream(Equipment.getItems())
+                .filter(s -> !s.getName().equals("Members object"))
                 .map(rsItem -> new IntPair(rsItem.getId(), rsItem.getStackSize())).collect(Collectors.toList());
         LinkedHashMap<Integer, Integer> map = Game.getClientPreferences().getProperties();
         List<IntPair> settings = Stream.of(

--- a/com/dax/walker/store/DaxStore.java
+++ b/com/dax/walker/store/DaxStore.java
@@ -1,0 +1,27 @@
+package com.dax.walker.store;
+
+import com.dax.walker.engine.definitions.PathLink;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DaxStore {
+
+    public DaxStore() {
+        this.pathLinks = new ArrayList<>(PathLink.getValues());
+    }
+
+    private List<PathLink> pathLinks;
+
+    public void addPathLink(PathLink link) {
+        this.pathLinks.add(link);
+    }
+
+    public void removePathLink(PathLink link) {
+        this.pathLinks.remove(link);
+    }
+
+    public List<PathLink> getPathLinks() {
+        return pathLinks;
+    }
+}


### PR DESCRIPTION
Exposes path link and allows the collection to be modified.

Usage:
```
DaxWalker walker = new DaxWalker(new Server());
 walker.getStore().addPathLink(new PathLink(new Position(1, 2, 3),
                new Position(4, 5, 6), (start, end, walkCondition) -> EntityHandler.handleCharter(CharterShip.Destination.PORT_KHAZARD, walkCondition)));
```